### PR TITLE
fix: use automation token for GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Install dependencies
@@ -32,11 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Install dependencies
@@ -45,6 +46,6 @@ jobs:
         run: npm run build
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary
- use the `AUTOMATION_PAT` secret for semantic-release's GitHub API token, matching the working DLS release workflow
- disable persisted checkout credentials in the release job so semantic-release uses the intended token
- update checkout/setup-node actions to the current DLS pattern

## Context
The `v4.0.0` package publish succeeded, but `@semantic-release/github` failed to create the GitHub Release with `401 Requires authentication` when posting to `/repos/nrccua/eslint-config/releases`. The existing workflow passed `${{ secrets.GITHUB_TOKEN }}` to semantic-release even though the repo/org is configured with `AUTOMATION_PAT` for release automation.

I manually created the missing release for the existing `v4.0.0` tag: https://github.com/nrccua/eslint-config/releases/tag/v4.0.0

## Validation
- `npm ci --ignore-scripts`
- `npm test`
- `npm run build`